### PR TITLE
make nginx config file path configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,5 @@ ssl_certs_common_name: "{{ external_hostname }}"
 # a space-delimited list of server names that nginx should respond to
 # https://nginx.org/en/docs/http/server_names.html
 server_names: "{{ external_hostname }}"
+
+nginx_proxy_vhost_path: "{{ nginx_vhost_path }}/https_proxy.conf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Add vhost config file
   template:
     src: vhost.conf
-    dest: "{{ nginx_vhost_path }}/https_proxy.conf"
+    dest: "{{ nginx_proxy_vhost_path }}"
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
Needed for backwards compatibility - the filename for the jenkins-deploy role was `jenkins.conf` prior to GSA/jenkins-deploy#36, and it's easier to keep the same path rather than juggle changing filenames.